### PR TITLE
refactor: assign-achievements response was changed and image key in therapist and tutor object in the findPatient response was changed by imageUrl

### DIFF
--- a/src/services/achievements.service.js
+++ b/src/services/achievements.service.js
@@ -602,7 +602,8 @@ module.exports = {
         achievementId,
         healthRecordId: patientExist.HealthRecord.id,
       },{
-        transaction
+        transaction,
+        returning: true,
       });
 
       if(!data) {
@@ -617,10 +618,18 @@ module.exports = {
       // Commit transaction
       await transaction.commit();
 
+      const newData = await Achievement.findOne({
+        where: {
+          id: data.id,
+          status: true,
+        }
+      });
+
       return {
         error: false,
         statusCode: 201,
         message: messages.achievements.success.assign,
+        data: dataStructure.findAchievementDataStructure(newData)
       }
 
     } catch (error) {

--- a/src/utils/dataStructure/data-structure.util.js
+++ b/src/utils/dataStructure/data-structure.util.js
@@ -455,7 +455,7 @@ module.exports = {
       tutor: data.tutor ?  {
         id: data.tutor.id,
         userId: data.tutor.userId,
-        image: data.tutor.User.imageUrl ?? null,
+        imageUrl: data.tutor.User.imageUrl ?? null,
         fullName: getFullName(data.tutor.Person),
         email: data.tutor.User.email,
         username: data.tutor.User.username,
@@ -465,7 +465,7 @@ module.exports = {
       therapist: data.therapist ? {
         id: data.therapist.id,
         userId: data.therapist.userId,
-        image: data.therapist.User.imageUrl,
+        imageUrl: data.therapist.User.imageUrl,
         fullName: getFullName(data.therapist.Person),
         email: data.therapist.User.email,
         username: data.therapist.User.username,


### PR DESCRIPTION
## Description
- assign-achievements response was changed, before this change the endpoint use to return just a message and now return the achievement information.
- image key in therapist and tutor object in the findPatient response was changed by imageUrl

## Type of change

## Tickets:
1. https://apphope.atlassian.net/jira/software/projects/HOPE/boards/1?assignee=6061380cea084b0069e8d494&jql=assignee%20%3D%206061380cea084b0069e8d494&selectedIssue=HOPE-259
2. https://apphope.atlassian.net/jira/software/projects/HOPE/boards/1?assignee=6061380cea084b0069e8d494&jql=assignee%20%3D%206061380cea084b0069e8d494&selectedIssue=HOPE-263

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (no functional changes, no api changes)
- [ ] This change requires a documentation update
- [ ] Other (please describe): 

## How Has This Been Tested?

Describe the tests you've run to verify the changes. Provide instructions for reproduction and indicate any relevant details for your test setup.

- [ ] Test A
- [ ] Test B

## Checklist:

- [X] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in areas hard to understand.
- [ ] I have made the corresponding changes to the documentation.
- [X] My changes do not generate new warnings.
- [ ] I have added tests that prove my solution is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [X] All dependent changes have been merged and published in subsequent modules.
- [X] I have reviewed my code and corrected any spelling mistakes.


## Views
![image](https://github.com/user-attachments/assets/2e442390-14ab-4fc5-8a20-b4f281304a44)
![image](https://github.com/user-attachments/assets/9cea80c3-f19c-4cb7-9748-34bbe95f8992)
