### PR TITLE
fix: general pictograms now can be used by tutor role

### DIFF
--- a/src/routes/pictogram.route.js
+++ b/src/routes/pictogram.route.js
@@ -8,7 +8,7 @@ const {
 } = require('@controllers/pictogram.controller');
 const { verifyToken, rolePermissions } = require('@middlewares');
 const {
-  roleConstants: { SUPERADMIN_ROLE, ADMIN_ROLE, THERAPIST_ROLE },
+  roleConstants: { SUPERADMIN_ROLE, ADMIN_ROLE, THERAPIST_ROLE, TUTOR_ROLE },
   permissionsConstants: {
     LIST_PICTOGRAM,
     GET_PICTOGRAM,
@@ -21,7 +21,7 @@ const multer = require('multer');
 
 const upload = multer({ storage: multer.memoryStorage() });
 
-router.get('/', verifyToken, rolePermissions([SUPERADMIN_ROLE, ADMIN_ROLE, THERAPIST_ROLE],[LIST_PICTOGRAM]), all);
+router.get('/', verifyToken, rolePermissions([SUPERADMIN_ROLE, ADMIN_ROLE, THERAPIST_ROLE, TUTOR_ROLE],[LIST_PICTOGRAM]), all);
 router.get('/:id', verifyToken, rolePermissions([SUPERADMIN_ROLE, ADMIN_ROLE, THERAPIST_ROLE],[GET_PICTOGRAM]), findOne);
 
 router.post('/', verifyToken, rolePermissions([SUPERADMIN_ROLE, ADMIN_ROLE],[CREATE_PICTOGRAM]),upload.single('imageFile'), create);

--- a/src/services/pictogram.service.js
+++ b/src/services/pictogram.service.js
@@ -8,7 +8,7 @@ const {
   dataStructure,
   azureImages
 } = require('@utils');
-const { pictogramContainer, defaultPictogramImage } = require('../config/variables.config');
+const { pictogramContainer, defaultPictogramImage } = require('@config/variables.config');
 
 
 /* eslint-disable radix */


### PR DESCRIPTION
## Description
- Tutor Role now can get all general pictograms.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (no functional changes, no api changes)
- [ ] This change requires a documentation update
- [ ] Other (please describe): 

## How Has This Been Tested?

Describe the tests you've run to verify the changes. Provide instructions for reproduction and indicate any relevant details for your test setup.

- [ ] Test A
- [ ] Test B

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in areas hard to understand.
- [ ] I have made the corresponding changes to the documentation.
- [X] My changes do not generate new warnings.
- [ ] I have added tests that prove my solution is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] All dependent changes have been merged and published in subsequent modules.
- [X] I have reviewed my code and corrected any spelling mistakes.

## Views
- ![image](https://github.com/user-attachments/assets/21034800-56db-419f-baad-beb66359e935)


