### PR TITLE
feat: only custom pictograms will be sent to the detail patients

### DIFF
--- a/src/helpers/patientPictogram.helper.js
+++ b/src/helpers/patientPictogram.helper.js
@@ -602,7 +602,51 @@ async function getPictogramsPatient(patientResponse, { categoryId, pictogramName
   }
 };
 
+
+async function getOnlyCustomPictogramsPatient(patientId) {
+  try {
+
+    const data = await PatientPictogram.findAll({
+      where: {
+        patientId,
+        status: true
+      },
+      order: [['name', 'ASC']],
+      attributes: ['id', 'name', 'imageUrl'],
+      include: [
+        {
+          model: Pictogram,
+          attributes: {
+            exclude: ['createdAt','updatedAt','status','categoryId']
+          },
+          include: {
+            model: Category,
+            attributes: {
+              exclude: ['createdAt','updatedAt','status']
+            }
+          }
+        }
+      ]
+    });
+
+    return {
+      error: false,
+      statusCode: 200,
+      message: messages.pictogram.success.all,
+      data: data.length > 0 ?  dataStructure.customPictogramDataStructure(data) : null,
+    }
+  } catch(error) {
+    logger.error(`${messages.pictogram.errors.service.base2}: ${error}`);
+    return {
+      error: true,
+      statusCode: 500,
+      message: messages.generalMessages.server,
+    }
+  }
+}
+
 module.exports = {
   getCustomPictograms,
   getPictogramsPatient,
+  getOnlyCustomPictogramsPatient
 }

--- a/src/services/patient.service.js
+++ b/src/services/patient.service.js
@@ -17,7 +17,7 @@ const {
   Achievement,
   sequelize
 } = require('@models/index.js');
-const { getProgress, userSendEmail, getCustomPictograms } = require('@helpers');
+const { getProgress, userSendEmail, getCustomPictograms, getOnlyCustomPictogramsPatient } = require('@helpers');
 const {
   pagination,
   messages,
@@ -1041,7 +1041,7 @@ module.exports = {
         }
       };
 
-      const { error, data:pictogramData } = await getCustomPictograms({ patientResponse: data });
+      const { error, data: pictogramData } = await getOnlyCustomPictogramsPatient(data.id);
       if(!error) {
         data.pictograms = pictogramData;
       }

--- a/src/services/patientPictograms.service.js
+++ b/src/services/patientPictograms.service.js
@@ -1,7 +1,7 @@
 const { Op, Sequelize } = require('sequelize');
 const { PatientPictogram, Patient, Pictogram, Category, TutorTherapist, User, UserRoles, sequelize } = require('@models');
 const logger = require('@config/logger.config');
-const { getPictogramsPatient } = require('@helpers');
+const { getPictogramsPatient, getOnlyCustomPictogramsPatient } = require('@helpers');
 const { roleConstants: constants } = require('@constants');
 const { pictogramContainer, defaultPictogramImage } = require('../config/variables.config');
 const {
@@ -139,7 +139,7 @@ module.exports = {
             error: false,
             statusCode: 200,
             message: messages.pictogram.success.all,
-            data: dataResponseByCategoryId.length > 0 ?  dataStructure.customPictogramDataStructure(dataResponseByCategoryId) : [],
+            data: dataResponseByCategoryId.length > 0 ?  dataStructure.customPictogramDataStructure(dataResponseByCategoryId) : null,
           }
         }
 
@@ -194,7 +194,7 @@ module.exports = {
             error: false,
             statusCode: 200,
             message: messages.pictogram.success.all,
-            data: dataResponse.length > 0 ?  dataStructure.customPictogramDataStructure(dataResponse) : [],
+            data: dataResponse.length > 0 ?  dataStructure.customPictogramDataStructure(dataResponse) : null,
           }
         }
 
@@ -222,7 +222,7 @@ module.exports = {
           error: false,
           statusCode: 200,
           message: messages.pictogram.success.all,
-          data: data.length > 0 ?  dataStructure.customPictogramDataStructure(data) : [],
+          data: data.length > 0 ?  dataStructure.customPictogramDataStructure(data) : null,
         }
       }
 
@@ -284,6 +284,9 @@ module.exports = {
         dataResponseByCategoryId.rows = dataStructure.customPictogramDataStructure(dataResponseByCategoryId.rows);
 
         const dataResponse = pagination.getPageData(dataResponseByCategoryId, page, limit);
+        if(dataResponse.data.length === 0) {
+          dataResponse.data = null;
+        }
 
         return {
           error: false,
@@ -347,6 +350,9 @@ module.exports = {
         dtaResponseByFilters.rows = dataStructure.customPictogramDataStructure(dtaResponseByFilters.rows);
 
         const dataResponse = pagination.getPageData(dtaResponseByFilters, page, limit);
+        if(dataResponse.data.length === 0) {
+          dataResponse.data = null;
+        }
 
         return {
           error: false,
@@ -383,6 +389,9 @@ module.exports = {
       data.rows = dataStructure.customPictogramDataStructure(data.rows);
 
       const dataResponse = pagination.getPageData(data, page, limit);
+      if(dataResponse.data.length === 0) {
+        dataResponse.data = null;
+      }
 
       return {
         error: false,

--- a/src/utils/dataStructure/data-structure.util.js
+++ b/src/utils/dataStructure/data-structure.util.js
@@ -442,13 +442,6 @@ module.exports = {
       },
       observations: observationsGotit.length > 0 ?  observationsGotit : null,
       achievements: patientAchievements.length > 0 ? patientAchievements : null,
-
-      /*
-        Lista de logros Conseguidos: {
-          Nombre
-          Imagen
-        }
-      */
       tutor: data.tutor ?  {
         id: data.tutor.id,
         userId: data.tutor.userId,


### PR DESCRIPTION
## Description
- pictograms key in findPatient response  only retrieve custom pictograms
- the endpoint allCustomPictograms return data === null if the patient does not have customPictograms this  validation
includes the filters too.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] This change requires a documentation update
- [ ] Other (please describe): 

## How Has This Been Tested?

Describe the tests you've run to verify the changes. Provide instructions for reproduction and indicate any relevant details for your test setup.

- [ ] Test A
- [ ] Test B

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in areas hard to understand.
- [ ] I have made the corresponding changes to the documentation.
- [ ] My changes do not generate new warnings.
- [ ] I have added tests that prove my solution is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [X] All dependent changes have been merged and published in subsequent modules.
- [X] I have reviewed my code and corrected any spelling mistakes.


## Views
- FindPatient:
![image](https://github.com/user-attachments/assets/a7ad3c47-2935-4265-98dd-ef1c933d1f0d)
![image](https://github.com/user-attachments/assets/6864818b-892b-4ac9-8b51-983dfaa651ff)

- allCustomPictograms:
![image](https://github.com/user-attachments/assets/4eb9c484-5eaa-43ee-829d-1b0b811018e4)
![image](https://github.com/user-attachments/assets/a02e07cb-feca-4d81-8f2b-0ae3e86b4907)
![image](https://github.com/user-attachments/assets/6765ae7d-5c17-4a1b-bf95-71f85afa3331)
