### PR TITLE
fix: customImage cant be removed if this is the default image or the image belongs to General Pictogram

### DIFF
--- a/src/controllers/patientPictograms.controller.js
+++ b/src/controllers/patientPictograms.controller.js
@@ -9,7 +9,6 @@ const {
 const {
   messages,
   formatJoiMessages,
-  formatErrorMessages
 } = require('@utils');
 const {
   patientPictogramsEntry,

--- a/src/services/patientPictograms.service.js
+++ b/src/services/patientPictograms.service.js
@@ -533,6 +533,7 @@ module.exports = {
       }
 
       // TODO: ImageUrl validation has to be here
+      /* eslint-disable no-param-reassign */
       if(file) {
         const { error, statusCode, message, url } = await azureImages.uploadImage(file, pictogramContainer);
 
@@ -638,10 +639,9 @@ module.exports = {
           include: [
             {
               model: User,
-              where:
-               {
-                 status: true,
-               }
+              where:{
+                status: true,
+              }
             }
           ]
         });
@@ -735,14 +735,18 @@ module.exports = {
         const imageName = patientPictogramExist.imageUrl.split('/').pop();
         let handleError;
 
-        if(patientPictogramExist.imageUrl === defaultPictogramImage) {
+        // In case the imageUrl from the patientPictograms is the default one or the same as the pictogram imageUrl we will update the image without 
+        // delete the old one.
+        if(patientPictogramExist.imageUrl === defaultPictogramImage || pictogramExist.imageUrl === patientPictogramExist.imageUrl) {
           const { url, ...restResponse}  = await azureImages.updateAndUploadImage(file, null, pictogramContainer);
           handleError = restResponse;
 
           resBody.imageUrl = url;
         }
 
-        if(patientPictogramExist.imageUrl !== defaultPictogramImage) {
+        // on the other hand, if the imageUrl from the patientPictograms is not the default or is different from the pictogram imageUrl we wiil update the image
+        // and delete the old one.
+        if(patientPictogramExist.imageUrl !== defaultPictogramImage || pictogramExist.imageUrl !== patientPictogramExist.imageUrl) {
           const { url, ...restResponse}  = await azureImages.updateAndUploadImage(file, imageName, pictogramContainer);
           handleError = restResponse;
 
@@ -939,8 +943,10 @@ module.exports = {
         }
       }
 
-      // Delete patientPictogram image in the azure container
-      if(patientPictogramExist.imageUrl !== defaultPictogramImage) {
+      // Delete patientPictogram image in the azure container only if the image is not the default one or if the image
+      // belongs to General Pictograms
+      if(patientPictogramExist.imageUrl !== pictogramExist.imageUrl) {
+        if(patientPictogramExist.imageUrl !== defaultPictogramImage) {
         const imageName = patientPictogramExist.imageUrl.split('/').pop();
         const { error, statusCode, message } = await azureImages.deleteAzureImage(imageName, pictogramContainer);
 
@@ -952,6 +958,7 @@ module.exports = {
             message
           }
         }
+      }
       }
 
       // Commit transaction


### PR DESCRIPTION
## Description
- removeCustomPictogram was refactored, the image cant be delete if the image belongs to general Pictogram or is the default image.
-  updateCustomPictogram was refactored, the image cant be removed if the image belongs to general Pictogram or is the default image.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in areas hard to understand.
- [ ] I have made the corresponding changes to the documentation.
- [X] My changes do not generate new warnings.
- [ ] I have added tests that prove my solution is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [X] All dependent changes have been merged and published in subsequent modules.
- [X] I have reviewed my code and corrected any spelling mistakes.
