### PR TITLE
fix: pictograms name size validation was refactored and removePictogram endpoint was fixed

### DIFF
--- a/src/services/pictogram.service.js
+++ b/src/services/pictogram.service.js
@@ -1,5 +1,5 @@
 const { Op } = require('sequelize');
-const { Pictogram, Category, sequelize } = require('@models/index');
+const { Pictogram, Category, PatientPictogram, sequelize } = require('@models/index');
 const logger = require('@config/logger.config');
 const {
   messages,
@@ -235,6 +235,7 @@ module.exports = {
       }
 
       // TODO: Image exist logic has to be here.
+      /* eslint-disable no-param-reassign */
       if(file) {
         const { error, statusCode, message, url } = await azureImages.uploadImage(file, pictogramContainer);
 
@@ -482,7 +483,23 @@ module.exports = {
         }
       }
 
+      // validate if pictogram has not custom pictograms associated.
+      const hasCustomPictograms = await PatientPictogram.findOne({
+        where: {
+          pictogramId: id,
+          status: true,
+        }
+      });
+      if(hasCustomPictograms) {
+        await transaction.rollback();
+        return {
+          error: true,
+          statusCode: 409,
+          message: messages.pictogram.errors.service.has_custom_pictograms,
+        }
+      }
 
+      // Update pictogram with status false in order to delete it.
       const pictogramUpdated = await Pictogram.update(
         {
           status: false,

--- a/src/utils/messages.utils.js
+++ b/src/utils/messages.utils.js
@@ -540,6 +540,7 @@ const messages = {
         delete: `Pictograma no fue eliminado`,
         pictogram_not_match: `El pictograma personalizado que intenta modificar no pertenece al Paciente solicitante`,
         pictogram_used: `El pictograma que desea reemplazar ya tiene una personalización asociada`,
+        has_custom_pictograms: `El pictograma que desea eliminar tiene pictogramas personalizados asociados`,
         all: `Pictogramas no encontrados`,
       },
       not_found: `Pictograma no encontrado`,

--- a/src/validations/patientPictograms.validation.js
+++ b/src/validations/patientPictograms.validation.js
@@ -7,7 +7,7 @@ module.exports = {
 
   createPatientPictogram(data) {
     const schema = joi.object().keys({
-      name: joi.string().strict().trim().min(3,'utf8').max(60, 'utf8').required().messages({
+      name: joi.string().strict().trim().min(1,'utf8').max(60, 'utf8').required().messages({
         'any.required': messages.pictogram.fields.name.required,
         'string.base': messages.pictogram.fields.name.base,
         'string.empty': messages.pictogram.fields.name.empty,
@@ -43,7 +43,7 @@ module.exports = {
         'number.base': messages.patient.fields.id.base,
         'number.positive': messages.patient.fields.id.positive,
       }),
-      name: joi.string().strict().trim().min(3,'utf8').max(60, 'utf8').empty(' ').messages({
+      name: joi.string().strict().trim().min(1,'utf8').max(60, 'utf8').empty(' ').messages({
         'string.base': messages.pictogram.fields.name.base,
         'string.empty': messages.pictogram.fields.name.empty,
         'string.trim': messages.pictogram.fields.name.trim,

--- a/src/validations/pictogram.validation.js
+++ b/src/validations/pictogram.validation.js
@@ -7,7 +7,7 @@ module.exports = {
 
   createPictogramValidation(data) {
     const schema = joi.object().keys({
-      name: joi.string().strict().trim().min(3,'utf8').max(60, 'utf8').required().messages({
+      name: joi.string().strict().trim().min(1,'utf8').max(60, 'utf8').required().messages({
         'any.required': messages.pictogram.fields.name.required,
         'string.base': messages.pictogram.fields.name.base,
         'string.empty': messages.pictogram.fields.name.empty,
@@ -33,7 +33,7 @@ module.exports = {
         'number.base': messages.pictogram.fields.id.base,
         'number.positive': messages.pictogram.fields.id.positive,
       }),
-      name: joi.string().strict().trim().min(3,'utf8').max(60, 'utf8').empty(' ').messages({
+      name: joi.string().strict().trim().min(1,'utf8').max(60, 'utf8').empty(' ').messages({
         'string.base': messages.pictogram.fields.name.base,
         'string.empty': messages.pictogram.fields.name.empty,
         'string.trim': messages.pictogram.fields.name.trim,


### PR DESCRIPTION
## Description
- minimum letters for create pictogram or custom pictogram name now is one letter.
- remove general pictogram is blocked if this pictogram is associated to custom pictograms.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactoring (no functional changes, no api changes)

## How Has This Been Tested?

Describe the tests you've run to verify the changes. Provide instructions for reproduction and indicate any relevant details for your test setup.

- [ ] Test A
- [ ] Test B

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in areas hard to understand.
- [ ] I have made the corresponding changes to the documentation.
- [X] My changes do not generate new warnings.
- [ ] I have added tests that prove my solution is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [X] All dependent changes have been merged and published in subsequent modules.
- [X] I have reviewed my code and corrected any spelling mistakes.


## Views
- Pictogram
<img width="915" height="819" alt="Pictogram Validation" src="https://github.com/user-attachments/assets/4b573ff4-1c96-4c91-aa40-07e95f940827" />
<img width="1022" height="840" alt="pictogram update" src="https://github.com/user-attachments/assets/7f9f2fc2-722a-42ee-9ee1-c9e563d9f696" />

- Custom Pictogram
<img width="999" height="819" alt="custompictogram validation" src="https://github.com/user-attachments/assets/3c13aebf-3d69-4310-9bad-7b4f36f3a60a" />
<img width="1110" height="858" alt="customPictogram updsate" src="https://github.com/user-attachments/assets/308f643c-de8b-4df5-a82e-42751ed0f126" />

- Pictograms remove validation
<img width="950" height="700" alt="image" src="https://github.com/user-attachments/assets/3487267f-65bd-494b-90d8-6aaaacf8d74e" />

